### PR TITLE
Ajout d'une option pour injecter un script dans le head au lieu de body

### DIFF
--- a/HTML/Document.php
+++ b/HTML/Document.php
@@ -256,6 +256,27 @@ class Document extends \DOMDocument
         ], $attributes)); 
     }
     
+    public function addScript($path, $directory = '/js/', array $attributes = [], $head = false)
+    {
+        $definition = array_merge([ 
+            'tag' => 'script', 
+            'attributes' => [ 
+                'src' => $directory . $path 
+            ] 
+        ], $attributes);
+        
+        if ($this instanceof Document) {
+          
+            if($head) {
+                return $this->select('head')->append($definition);
+            }
+            
+            return $this->body->append($definition);
+        } else {
+            return $this->append($definition);
+        }
+    }
+    
     public function select($selector)
     {
         return $this->documentElement->select($selector);

--- a/HTML/NodeTrait.php
+++ b/HTML/NodeTrait.php
@@ -158,22 +158,6 @@ trait NodeTrait
         return $node;
     }
     
-    public function addScript($path, $directory = '/js/', array $attributes = [])
-    {
-        $definition = array_merge([ 
-            'tag' => 'script', 
-            'attributes' => [ 
-                'src' => $directory . $path 
-            ] 
-        ], $attributes);
-        
-        if ($this instanceof Document) {
-            return $this->body->append($definition);
-        } else {
-            return $this->append($definition);
-        }
-    }
-    
     public function __toString()
     {
         return $this->ownerDocument->saveHTML($this);


### PR DESCRIPTION
J'ai déplacé addScript dans Document.php et y ait ajouté un argument $head à la fin.

Le but est que le script JS puisse être injecté dans `<head />` au lieu de `<body />` quand on manipule un document. Si il s'agit d'un fragment l'argument sera ignoré. Tu peux ajouter une erreur fatale dessus par principe :)
